### PR TITLE
Add static routes on Core-2 and Core-3

### DIFF
--- a/configs/core-2.cfg
+++ b/configs/core-2.cfg
@@ -99,6 +99,7 @@ ip forward-protocol nd
 !
 no ip http server
 no ip http secure-server
+ip route 0.0.0.0 0.0.0.0 10.255.255.25
 ip ssh server algorithm authentication password
 !
 logging host 192.168.1.1

--- a/configs/core-3.cfg
+++ b/configs/core-3.cfg
@@ -99,6 +99,7 @@ ip forward-protocol nd
 !
 no ip http server
 no ip http secure-server
+ip route 0.0.0.0 0.0.0.0 10.255.255.26
 ip ssh server algorithm authentication password
 !
 logging host 192.168.1.1

--- a/inventory/host_vars/core-2/host_info.yml
+++ b/inventory/host_vars/core-2/host_info.yml
@@ -8,3 +8,7 @@ syslog_servers:
 
 ntp_servers:
   - "192.168.100.1"
+
+static_routes:
+  - ip_network: "0.0.0.0/0"
+    next_hop: "10.255.255.25"

--- a/inventory/host_vars/core-3/host_info.yml
+++ b/inventory/host_vars/core-3/host_info.yml
@@ -8,3 +8,7 @@ syslog_servers:
 
 ntp_servers:
   - "192.168.100.1"
+
+static_routes:
+  - ip_network: "0.0.0.0/0"
+    next_hop: "10.255.255.26"


### PR DESCRIPTION
Add static routes between Core-2 and Core-3 to prevent routing outages if uplinks to Core-1 fail